### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@
 pass to mem::replace is hard. Unfortunately, `replace_map` is not safe
 in all cases, so care must be taken when using it.
 
+--
+
+Notice: this crate was built pre-rust 1.0, and is deprecated. See [take_mut](https://crates.io/crates/take_mut) for an equivalent crate with a safe API which is supported today on stable rust.


### PR DESCRIPTION
This crate seems to be deprecated, and take_mut is definitely a supported equivalent.